### PR TITLE
Fix issue #68: Faster inference and more accurate point estimates with Lag-Lama

### DIFF
--- a/lag_llama/gluon/estimator.py
+++ b/lag_llama/gluon/estimator.py
@@ -98,6 +98,10 @@ class LagLlamaEstimator(PyTorchLightningEstimator):
         Controls the sampling of windows during training.
     validation_sampler
         Controls the sampling of windows during validation.
+    use_single_pass_sampling
+        If True, use a single forward pass and sample N times from the saved distribution, much more efficient.
+        If False, perform N forward passes and maintain N parallel prediction paths, this is true probalistic forecasting.
+            (default: False)
     """
 
     @validated()
@@ -155,6 +159,7 @@ class LagLlamaEstimator(PyTorchLightningEstimator):
         track_loss_per_series: bool = False,
         ckpt_path: Optional[str] = None,
         nonnegative_pred_samples: bool = False,
+        use_single_pass_sampling: bool = False,
         device: torch.device = torch.device("cuda")
     ) -> None:
         default_trainer_kwargs = {"max_epochs": 100}
@@ -199,6 +204,7 @@ class LagLlamaEstimator(PyTorchLightningEstimator):
         self.batch_size = batch_size
         self.num_batches_per_epoch = num_batches_per_epoch
         self.nonnegative_pred_samples = nonnegative_pred_samples
+        self.use_single_pass_sampling = use_single_pass_sampling
 
         self.train_sampler = train_sampler or ExpectedNumInstanceSampler(
             num_instances=1.0,

--- a/lag_llama/gluon/lightning_module.py
+++ b/lag_llama/gluon/lightning_module.py
@@ -102,6 +102,7 @@ class LagLlamaLightningModule(LightningModule):
         track_loss_per_series: bool = False,
         nonnegative_pred_samples: bool = False,
         use_kv_cache: bool = True,
+        use_single_pass_sampling: bool = False,
     ):
         super().__init__()
         self.save_hyperparameters()
@@ -147,6 +148,7 @@ class LagLlamaLightningModule(LightningModule):
         self.train_loss_dict_per_series = {}
         self.val_loss_dict_per_series = {}
         self.use_kv_cache = use_kv_cache
+        self.use_single_pass_sampling = use_single_pass_sampling
         self.transforms = []
         aug_probs = dict(
             Jitter=dict(prob=self.jitter_prob, sigma=self.jitter_sigma),
@@ -225,47 +227,91 @@ class LagLlamaLightningModule(LightningModule):
             past_time_feat = kwargs["past_time_feat"]
             future_time_feat = kwargs["future_time_feat"]
 
+        use_single_pass_sampling = self.use_single_pass_sampling
+
         future_samples = []
-        for t in range(self.prediction_length):
-            params, loc, scale = self.model(
-                *args,
-                past_time_feat=past_time_feat if self.time_feat else None,
-                future_time_feat=future_time_feat[..., : t + 1, :] if self.time_feat else None,
-                past_target=past_target,
-                past_observed_values=past_observed_values,
-                use_kv_cache=self.use_kv_cache,
-            )
 
-            sliced_params = [
-                p[:, -1:] for p in params
-            ]  # Take the last timestep predicted. Each tensor is of shape (#bsz, 1)
-            # Singular distribution is used for getting the greedy prediction (mean)
-            distr = self.model.distr_output.distribution(sliced_params, loc, scale)
-            greedy_prediction = distr.mean # (#bsz, 1)
-
-            repeated_sliced_params = [
-                    p[:, -1:].repeat_interleave(
-                    self.model.num_parallel_samples, 0
-                ) for p in params
-            ] # Take the last timestep predicted and repeat for number of samples. Each tensor is of shape (#bsz*#parallel_samples, 1)
-            repeated_loc = loc.repeat_interleave(
-                    self.model.num_parallel_samples, 0
+        if use_single_pass_sampling:
+            # Single-pass sampling mode: Single forward pass per step, save distribution parameters, sample `num_parallel_samples` times, add mean to context.
+            for t in range(self.prediction_length):
+                params, loc, scale = self.model(
+                    *args,
+                    past_time_feat=past_time_feat if self.time_feat else None,
+                    future_time_feat=future_time_feat[..., : t + 1, :] if self.time_feat else None,
+                    past_target=past_target,
+                    past_observed_values=past_observed_values,
+                    use_kv_cache=self.use_kv_cache,
                 )
-            repeated_scale = scale.repeat_interleave(
-                    self.model.num_parallel_samples, 0
-                )
-            # Repeated distribution is used for getting the parallel samples
-            # (distr.sample([self.model.num_parallel_samples]) seems to give terrible results)
-            repeated_distr = self.model.distr_output.distribution(repeated_sliced_params, repeated_loc, repeated_scale)
-            sample = repeated_distr.sample()  # (#bsz*#parallel_samples, 1)
-            if self.nonnegative_pred_samples:
-                sample = F.relu(sample)
-            future_samples.append(sample)
 
-            past_target = torch.cat((past_target, greedy_prediction), dim=1)
-            past_observed_values = torch.cat(
-                (past_observed_values, torch.ones_like(greedy_prediction)), dim=1
-            )
+                sliced_params = [
+                    p[:, -1:] for p in params
+                ]  # Take the last timestep predicted. Each tensor is of shape (#bsz, 1)
+                # Singular distribution is used for getting the greedy prediction (mean)
+                distr = self.model.distr_output.distribution(sliced_params, loc, scale)
+                greedy_prediction = distr.mean # (#bsz, 1)
+
+                repeated_sliced_params = [
+                        p[:, -1:].repeat_interleave(
+                        self.model.num_parallel_samples, 0
+                    ) for p in params
+                ] # Take the last timestep predicted and repeat for number of samples. Each tensor is of shape (#bsz*#parallel_samples, 1)
+                repeated_loc = loc.repeat_interleave(
+                        self.model.num_parallel_samples, 0
+                    )
+                repeated_scale = scale.repeat_interleave(
+                        self.model.num_parallel_samples, 0
+                    )
+                # Repeated distribution is used for getting the parallel samples
+                # (distr.sample([self.model.num_parallel_samples]) seems to give terrible results)
+                repeated_distr = self.model.distr_output.distribution(repeated_sliced_params, repeated_loc, repeated_scale)
+                sample = repeated_distr.sample()  # (#bsz*#parallel_samples, 1)
+                if self.nonnegative_pred_samples:
+                    sample = F.relu(sample)
+                future_samples.append(sample)
+
+                past_target = torch.cat((past_target, greedy_prediction), dim=1)
+                past_observed_values = torch.cat(
+                    (past_observed_values, torch.ones_like(greedy_prediction)), dim=1
+                )
+        else:
+            # Original probabilistic forecasting: Duplicate input, `num_parallel_samples` forward passes per step, sample each distribution once, add samples to context.
+            repeated_past_target = past_target.repeat_interleave(self.model.num_parallel_samples, 0)
+            repeated_past_observed_values = past_observed_values.repeat_interleave(self.model.num_parallel_samples, 0)
+            if self.time_feat:
+                repeated_past_time_feat = past_time_feat.repeat_interleave(self.model.num_parallel_samples, 0)
+                repeated_future_time_feat = future_time_feat.repeat_interleave(self.model.num_parallel_samples, 0)
+
+            for t in range(self.prediction_length):
+                if self.time_feat:
+                    params, loc, scale = self.model(
+                        *args,
+                        past_time_feat=repeated_past_time_feat,
+                        future_time_feat=repeated_future_time_feat[..., : t + 1, :],
+                        past_target=repeated_past_target,
+                        past_observed_values=repeated_past_observed_values,
+                        use_kv_cache=self.use_kv_cache,
+                    )
+                else:
+                    params, loc, scale = self.model(
+                        *args,
+                        past_time_feat=None,
+                        future_time_feat=None,
+                        past_target=repeated_past_target,
+                        past_observed_values=repeated_past_observed_values,
+                        use_kv_cache=self.use_kv_cache,
+                    )
+
+                sliced_params = [p[:, -1:] for p in params]
+                distr = self.model.distr_output.distribution(sliced_params, loc, scale)
+                sample = distr.sample()
+                if self.nonnegative_pred_samples:
+                    sample = F.relu(sample)
+                future_samples.append(sample)
+
+                repeated_past_target = torch.cat((repeated_past_target, sample), dim=1)
+                repeated_past_observed_values = torch.cat(
+                    (repeated_past_observed_values, torch.ones_like(sample)), dim=1
+                )
 
         self.model.reset_cache()
 


### PR DESCRIPTION
## Fixes #68

This PR addresses the inefficiencies in inference speed for the Lag-Lama model, specifically in the parallel sampling process, as discussed in issue #68.

### Optimised Sampling Process:
- Reduced redundant forward passes by avoiding input duplication. Instead of duplicating the input K times and performing K parallel forward passes, a single forward pass is now used.
- The distribution parameters (degree of freedom, mean, and scale) are saved after a single forward pass.
- Multiple samples are then taken by duplicating the saved distribution parameters before sampling, this was used rather than the originally suggested `distr.sample([K])`, which was found to give poor results.

### Handling Auto-Regressive Forecasting:
- While the original model was deterministic, it would build a series of paths from the random samples since this is forecasting using an auto-regressive model.
- To maintain a single forward pass, the greedy assumption is made that the previous sample was the mean. This mean is added to the history, and the next set of sampled predictions is made.
- The previous approach maintained a series of parallel paths with all random samples, requiring many paths. The new approach should be sufficiently accurate while being much more efficient.