### PR TITLE
Fix device select

### DIFF
--- a/lag_llama/gluon/estimator.py
+++ b/lag_llama/gluon/estimator.py
@@ -477,7 +477,7 @@ class LagLlamaEstimator(PyTorchLightningEstimator):
                 prediction_net=module,
                 batch_size=self.batch_size,
                 prediction_length=self.prediction_length,
-                device="cuda" if torch.cuda.is_available() else "cpu",
+                device=self.device,
             )
         else:
             return PyTorchPredictor(
@@ -486,5 +486,5 @@ class LagLlamaEstimator(PyTorchLightningEstimator):
                 prediction_net=module,
                 batch_size=self.batch_size,
                 prediction_length=self.prediction_length,
-                device="cuda" if torch.cuda.is_available() else "cpu",
+                device=self.device,
             )


### PR DESCRIPTION
Create_predictor() in gluon/estimator.py did not get the self.device parameter which was set in upper Class. 

Instead it was hardcoded with Cuda or CPU.
If you want to work with mps for example you can now do this by just passing torch.device("mps") to the LagLlamaEstimator.

Previously nothing happened while doing this.

Cheers